### PR TITLE
chore: enable Detekt for all subprojects and update config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import io.gitlab.arturbosch.detekt.Detekt
+
 plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
@@ -12,7 +14,19 @@ plugins {
 
 detekt {
     buildUponDefaultConfig = true
-    allRules = false
+    allRules = true
     parallel = true
     config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
+}
+
+tasks.register("detektAll") {
+    description = "Runs Detekt on all subprojects"
+    group = "verification"
+
+    // For each subproject, add all Detekt tasks as dependencies
+    rootProject.subprojects.forEach { subproject ->
+        subproject.tasks.matching { it is Detekt }.configureEach {
+            this@register.dependsOn(this)
+        }
+    }
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -7,6 +6,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.detekt)
 }
 
 kotlin {


### PR DESCRIPTION
Detekt is now enabled for all subprojects by registering a 'detektAll' task in the root build.gradle.kts. The Detekt configuration is updated to enable all rules, and the Detekt plugin is applied to the composeApp module.